### PR TITLE
ルートへのルーティングの設定を行う。

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   resources :articles
   resources :sample_articles
+  root :to => 'articles#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
## 概要
 - ルートへのルーティングの設定を行う
 - `root :to => 'articles#index'`を追記